### PR TITLE
feat: Material3風UIと動的翻訳ルート設定機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,15 @@
 
       <md-outlined-text-field id="inputText" label="元の文章" rows="6" textarea></md-outlined-text-field>
 
+      <section class="language-config-section">
+        <h2>経由する言語</h2>
+        <div id="language-selectors"></div>
+        <div class="buttons">
+            <md-outlined-button id="addLangBtn">+</md-outlined-button>
+            <md-outlined-button id="removeLangBtn">-</md-outlined-button>
+        </div>
+      </section>
+
       <md-filled-button id="translateBtn">翻訳開始</md-filled-button>
 
       <section class="output-section">

--- a/script.js
+++ b/script.js
@@ -1,9 +1,70 @@
+// TODO: APIから動的に取得するように変更する
+const AVAILABLE_LANGUAGES = [
+    { code: "en", name: "英語" },
+    { code: "es", name: "スペイン語" },
+    { code: "fr", name: "フランス語" },
+    { code: "de", name: "ドイツ語" },
+    { code: "it", name: "イタリア語" },
+    { code: "pt", name: "ポルトガル語" },
+    { code: "ru", name: "ロシア語" },
+    { code: "ja", name: "日本語" },
+    { code: "ko", name: "韓国語" },
+    { code: "zh", name: "中国語" },
+    { code: "ar", name: "アラビア語" },
+    { code: "hi", name: "ヒンディー語" },
+    { code: "ug", name: "ウイグル語" },
+    { code: "la", name: "ラテン語" },
+    { code: "ky", name: "キルギス語" },
+    { code: "xh", name: "コーサ語" },
+];
+
+const languageSelectorsContainer = document.getElementById("language-selectors");
+
+function createLanguageSelector(selectedCode) {
+    const select = document.createElement("md-outlined-select");
+    select.label = "言語";
+
+    AVAILABLE_LANGUAGES.forEach(lang => {
+        const option = document.createElement("md-select-option");
+        option.value = lang.code;
+        option.innerText = lang.name;
+        if (lang.code === selectedCode) {
+            option.selected = true;
+        }
+        select.appendChild(option);
+    });
+
+    languageSelectorsContainer.appendChild(select);
+}
+
+document.getElementById("addLangBtn").addEventListener("click", () => {
+    createLanguageSelector(AVAILABLE_LANGUAGES[0].code);
+});
+
+document.getElementById("removeLangBtn").addEventListener("click", () => {
+    if (languageSelectorsContainer.lastChild) {
+        languageSelectorsContainer.removeChild(languageSelectorsContainer.lastChild);
+    }
+});
+
+
+// 初期状態としていくつかのセレクターを設置
+createLanguageSelector("ug");
+createLanguageSelector("la");
+createLanguageSelector("ky");
+
+
 async function translate(text, from, to) {
   const res = await fetch("https://translate.argosopentech.com/translate", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ q: text, source: from, target: to, format: "text" }),
   });
+
+  if (!res.ok) {
+      const error = await res.text();
+      throw new Error(`翻訳APIエラー: ${res.status} ${error}`);
+  }
 
   const data = await res.json();
   return data.translatedText;
@@ -15,29 +76,36 @@ document.getElementById("translateBtn").addEventListener("click", async () => {
 
   const steps = [];
   let text = inputText;
+  let lastLang = "ja";
 
-  const langs = [
-    ["ja", "ug"], // ウイグル語
-    ["ug", "la"], // ラテン語
-    ["la", "ky"], // キルギス語
-    ["ky", "xh"], // コーサ語
-    ["xh", "ko"], // 韓国語
-    ["ko", "ja"], // 日本語に戻す
-  ];
+  const selectedLangs = [...languageSelectorsContainer.children].map(s => s.value);
 
-  for (const [from, to] of langs) {
-    const nextText = await translate(text, from, to);
-    steps.push({ from, to, text: nextText });
-    text = nextText;
+  const langs = [];
+  for (const langCode of selectedLangs) {
+      langs.push([lastLang, langCode]);
+      lastLang = langCode;
   }
+  langs.push([lastLang, "ja"]); // 最後に日本語に戻す
 
-  document.getElementById("finalOutput").innerText = text;
+  document.getElementById("finalOutput").innerText = "翻訳中...";
+  document.getElementById("stepsOutput").innerText = "";
 
-  const stepHTML = steps
-    .map((step, i) => {
-      return `➡️ ${step.from.toUpperCase()} → ${step.to.toUpperCase()}:\n${step.text}\n`;
-    })
-    .join("\n\n");
+  try {
+    for (const [from, to] of langs) {
+      const nextText = await translate(text, from, to);
+      steps.push({ from, to, text: nextText });
+      text = nextText;
 
-  document.getElementById("stepsOutput").innerText = stepHTML;
+      //途中経過を表示
+      const stepHTML = steps
+        .map((step) => `➡️ ${step.from.toUpperCase()} → ${step.to.toUpperCase()}:\n${step.text}\n`)
+        .join("\n\n");
+      document.getElementById("stepsOutput").innerText = stepHTML;
+    }
+
+    document.getElementById("finalOutput").innerText = text;
+  } catch (e) {
+      console.error(e);
+      document.getElementById("finalOutput").innerText = `エラーが発生しました：\n${e.message}`;
+  }
 });

--- a/style.css
+++ b/style.css
@@ -1,9 +1,21 @@
+:root {
+  --md-sys-color-primary: #6750a4;
+  --md-sys-color-on-primary: #ffffff;
+  --md-sys-color-primary-container: #eaddff;
+  --md-sys-color-on-primary-container: #21005d;
+  --md-sys-color-surface: #fdf7ff;
+  --md-sys-color-on-surface: #1c1b1f;
+  --md-sys-color-surface-variant: #e7e0ec;
+  --md-sys-color-on-surface-variant: #49454f;
+  --md-sys-color-outline: #79747e;
+}
+
 body {
   margin: 0;
   padding: 0;
   font-family: 'Noto Sans JP', sans-serif;
-  background-color: #fefefe;
-  color: #333;
+  background-color: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
   display: flex;
   justify-content: center;
 }
@@ -17,34 +29,76 @@ main {
 h1 {
   font-size: 2rem;
   margin-bottom: 0.5rem;
-  color: #6200ee;
+  color: var(--md-sys-color-primary);
+  font-weight: 600;
 }
 
 .description {
   margin-bottom: 1.5rem;
   font-size: 1rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+md-outlined-text-field {
+  width: 100%;
+  --md-outlined-text-field-container-shape: 16px;
 }
 
 md-filled-button {
   margin-top: 1rem;
   display: block;
+  width: 100%;
+  --md-filled-button-container-shape: 16px;
+  --md-filled-button-label-text-font: 'Noto Sans JP';
+}
+
+.language-config-section {
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    border: 1px solid var(--md-sys-color-outline);
+    border-radius: 16px;
+    padding: 1.5rem;
+}
+
+#language-selectors {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.language-config-section .buttons {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
 }
 
 .output-section {
-  margin-top: 2rem;
+  margin-top: 2.5rem;
+}
+
+h2 {
+    color: var(--md-sys-color-primary);
+    font-weight: 500;
+    margin-bottom: 1rem;
 }
 
 .result-box {
-  padding: 1rem;
+  padding: 1.5rem;
   margin-top: 0.5rem;
   white-space: pre-wrap;
+  background-color: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
+  border-radius: 16px;
 }
 
 .steps {
-  background-color: #f3f3f3;
-  border-radius: 8px;
-  padding: 1rem;
+  background-color: var(--md-sys-color-surface-variant);
+  color: var(--md-sys-color-on-surface-variant);
+  border-radius: 16px;
+  padding: 1.5rem;
   margin-top: 1rem;
   font-size: 0.95rem;
   white-space: pre-wrap;
+  line-height: 1.6;
 }


### PR DESCRIPTION
あなたの要望に基づき、以下の2つの主要な変更を実装しました。

1.  **UIをMaterial 3風に刷新**
    - `style.css`を全面的に書き換え、Material 3のデザイントークン（カラー、シェイプ、タイポグラフィ）に基づいたスタイルを適用しました。
    - CSSカスタムプロパティを使用して、テーマカラーを管理しやすくしました。

2.  **中間言語の数と種類を設定可能に**
    - `index.html`に、経由する言語を動的に追加・削除するためのUI（「+」「-」ボタンと選択用ドロップダウン）を追加しました。
    - `script.js`をリファクタリングし、以下の機能を追加しました。
        - 選択された言語に基づいて翻訳チェーンを動的に構築するロジック。
        - 翻訳処理中の途中経過を画面に表示する機能。 - API呼び出しの基本的なエラーハンドリング。
    - (注) APIから対応言語リストを動的に取得する部分については、ネットワークの問題で実装できませんでした。そのため、現在はハードコードされた言語リストを使用しています。